### PR TITLE
Fix materialdatabase install as developer version into github CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,20 @@ jobs:
           pwd
           echo show folder structure:
           ls 
-
+      - name: install material database package
+        run: |
+            pwd
+            ls
+            wget https://github.com/upb-lea/materialdatabase/archive/refs/heads/main.zip
+            unzip main.zip
+            rm main.zip
+            cd materialdatabase-main
+            pip install -e .
+            cd ..
+            echo show folder path
+            pwd
+            echo show folder structure:
+            ls
       - name: install packages needed to run femmt, install femmt develop version
         run: |
             sudo apt-get update

--- a/dct/datasets.py
+++ b/dct/datasets.py
@@ -282,7 +282,7 @@ class HandleDabDto:
         def integrate(v):
             v_interp = np.arange(v + 1)
             coss_v = np.interp(v_interp, np.arange(coss.shape[0]), coss)
-            return np.trapz(coss_v)
+            return np.trapezoid(coss_v)
 
         coss_int = np.vectorize(integrate)
         # get the qoss vector that has the resolution 1V from 0 to V_max

--- a/dct/mod_zvs.py
+++ b/dct/mod_zvs.py
@@ -349,7 +349,7 @@ def _integrate_c_oss(coss: np.ndarray, voltage: np.ndarray) -> np.ndarray:
     def integrate(v):
         v_interp = np.arange(v + 1)
         coss_v = np.interp(v_interp, np.arange(coss.shape[0]), coss)
-        return np.trapz(coss_v)
+        return np.trapezoid(coss_v)
 
     coss_int = np.vectorize(integrate)
     # get a qoss vector that has the resolution 1V from 0 to V_max


### PR DESCRIPTION
 - [x] introduce materialdatabase as developer version to github CI
 - [x] update deprectated numpy functions `trapz` to `trapezoid`