### PR TITLE
Read debug.toml to enter debug mode

### DIFF
--- a/dct/dctmainctl.py
+++ b/dct/dctmainctl.py
@@ -979,7 +979,7 @@ class DctMainCtl:
         is_failed, issue_report = dct.CircuitOptimization.verify_optimization_parameter(toml_circuit)
         if is_failed:
             raise ValueError("Circuit optimization parameter in file ",
-                             f"{toml_prog_flow.configuration_data_files.heat_sink_configuration_file} are inconsistent!\n", issue_report)
+                             f"{toml_prog_flow.configuration_data_files.circuit_configuration_file} are inconsistent!\n", issue_report)
 
         # Check, if electrical optimization is to skip
         if toml_prog_flow.circuit.calculation_mode == "skip":

--- a/dct/dctmainctl.py
+++ b/dct/dctmainctl.py
@@ -895,15 +895,13 @@ class DctMainCtl:
         # --------------------------
         # Debug
         # --------------------------
-        debug_toml_filepath = os.path.join(workspace_path, "debug.toml")
+        debug_toml_filepath = os.path.join(workspace_path, "debug_config.toml")
         is_debug_loaded, debug_dict = self.load_toml_file(debug_toml_filepath)
         if is_debug_loaded:
             logger.info("debug.toml config found.")
             toml_debug = dct.Debug(**debug_dict)
         else:
-            logger.info("no debug.toml config found.")
             toml_debug = dct.Debug(general=dct.DebugGeneral(is_debug=False))
-        logger.info(f"Debug mode: {toml_debug.general.is_debug}")
 
         # --------------------------
         # Flow control

--- a/dct/dctmainctl.py
+++ b/dct/dctmainctl.py
@@ -976,8 +976,8 @@ class DctMainCtl:
             raise ValueError(f"Circuit configuration file: {toml_prog_flow.configuration_data_files.circuit_configuration_file} does not exist.")
 
         # Verify optimization parameter
-        is_failed, issue_report = dct.CircuitOptimization.verify_optimization_parameter(toml_circuit)
-        if is_failed:
+        is_consistent, issue_report = dct.CircuitOptimization.verify_optimization_parameter(toml_circuit)
+        if not is_consistent:
             raise ValueError("Circuit optimization parameter in file ",
                              f"{toml_prog_flow.configuration_data_files.circuit_configuration_file} are inconsistent!\n", issue_report)
 
@@ -1015,8 +1015,8 @@ class DctMainCtl:
             raise ValueError(f"Inductor configuration file: {inductor_toml_filepath} does not exist.")
 
         # Verify optimization parameter
-        is_failed, issue_report = dct.InductorOptimization.verify_optimization_parameter(toml_inductor)
-        if is_failed:
+        is_consistent, issue_report = dct.InductorOptimization.verify_optimization_parameter(toml_inductor)
+        if not is_consistent:
             raise ValueError("Inductor optimization parameter in file ",
                              f"{toml_prog_flow.configuration_data_files.inductor_configuration_file} are inconsistent!\n", issue_report)
 
@@ -1053,8 +1053,8 @@ class DctMainCtl:
             raise ValueError(f"Transformer configuration file: {transformer_toml_filepath} does not exist.")
 
         # Verify optimization parameter
-        is_failed, issue_report = dct.TransformerOptimization.verify_optimization_parameter(toml_transformer)
-        if is_failed:
+        is_consistent, issue_report = dct.TransformerOptimization.verify_optimization_parameter(toml_transformer)
+        if not is_consistent:
             raise ValueError("Transformer optimization parameter in file ",
                              f"{toml_prog_flow.configuration_data_files.transformer_configuration_file} are inconsistent!\n", issue_report)
 
@@ -1090,8 +1090,8 @@ class DctMainCtl:
             raise ValueError(f"Heat sink configuration file: {heat_sink_toml_filepath} does not exist.")
 
         # Verify optimization parameter
-        is_failed, issue_report = dct.HeatSinkOptimization.verify_optimization_parameter(toml_heat_sink)
-        if is_failed:
+        is_consistent, issue_report = dct.HeatSinkOptimization.verify_optimization_parameter(toml_heat_sink)
+        if not is_consistent:
             raise ValueError("Heat sink optimization parameter in file "
                              f"{toml_prog_flow.configuration_data_files.heat_sink_configuration_file} are inconsistent!\n", issue_report)
 

--- a/dct/generate_toml.py
+++ b/dct/generate_toml.py
@@ -43,7 +43,8 @@ def generate_flow_control_toml(working_directory: str) -> None:
         inductor = "no"          # After inductor Pareto front calculations of for all correspondent electrical points
         transformer = "no"       # After transformer Pareto front calculations of for all correspondent electrical points
         heat_sink = "no"         # After heat sink Pareto front calculation
-        summary = "no"           # After heat sink Pareto front calculation
+        pre_summary = "no"       # After pre-summary
+        summary = "no"           # After summary
     
     [conditional_breakpoints] # conditional breakpoints in case of bad definition array (only for experts and currently not implemented)
         circuit = 1000           # Number of trials with ZVS less than 70%

--- a/dct/toml_checker.py
+++ b/dct/toml_checker.py
@@ -8,6 +8,21 @@ from pydantic import BaseModel
 # own libraries
 from dct.circuit_enums import SamplingEnum
 
+
+# ######################################################
+# debug
+# ######################################################
+
+class DebugGeneral(BaseModel):
+    """Debug mode general information."""
+
+    is_debug: bool
+
+class Debug(BaseModel):
+    """General information in debug configuration."""
+
+    general: DebugGeneral
+
 # ######################################################
 # flow control
 # ######################################################

--- a/workspace/progFlow.toml
+++ b/workspace/progFlow.toml
@@ -9,7 +9,8 @@
     inductor = "no"    # After inductor paretofront calculations of for all correspondent electrical points
     transformer = "no" # After transformer paretofront calculations of for all correspondent electrical points
     heat_sink = "no"    # After heatsink paretofront calculation
-    summary = "no"    # After heatsink paretofront calculation
+    pre_summary = "no"    # After pre-summary calculation
+    summary = "no"    # After summary calculation
 
 [conditional_breakpoints] # conditional breakpoints in case of bad definition array (only for experts and currently not implemented)
     circuit = 1000        # Number of trials with ZVS less than 70%


### PR DESCRIPTION
This PR introduces a configurable debug mode.
 * if there is a file `debug.toml`, the settings will be read
 * If inside this file, the debug mode is enabled, the program will enter the debug mode
 * This file can be extended in future with new features, e.g. a more detailed configurable debugging mode. Therefore, the debug mode can be enabled/disabled inside this file while keeping the file (and the other individual settings)
 * In case of no file found, the debug mode is not entered

`debug.toml` must look like this:
```
[general]
    is_debug = true
```